### PR TITLE
Show homepage posts grouped into category rows

### DIFF
--- a/src/components/widgets/BlogLatestPosts.astro
+++ b/src/components/widgets/BlogLatestPosts.astro
@@ -3,8 +3,8 @@ import { APP_BLOG } from 'astrowind:config';
 
 import Grid from '~/components/blog/Grid.astro';
 
-import { getBlogPermalink } from '~/utils/permalinks';
-import { findLatestPosts } from '~/utils/blog';
+import { getBlogPermalink, getPermalink } from '~/utils/permalinks';
+import { findLatestPosts, findPostsByCategory } from '~/utils/blog';
 import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
 import type { Widget } from '~/types';
 import Button from '~/components/ui/Button.astro';
@@ -15,14 +15,16 @@ export interface Props extends Widget {
   linkUrl?: string | URL;
   information?: string;
   count?: number;
+  category?: string;
 }
 
 const {
   title = await Astro.slots.render('title'),
   linkText = 'View all posts',
-  linkUrl = getBlogPermalink(),
+  linkUrl,
   information = await Astro.slots.render('information'),
   count = 4,
+  category,
 
   id,
   isDark = false,
@@ -30,11 +32,17 @@ const {
   bg = await Astro.slots.render('bg'),
 } = Astro.props;
 
-const posts = APP_BLOG.isEnabled ? await findLatestPosts({ count }) : [];
+const posts = APP_BLOG.isEnabled
+  ? category
+    ? await findPostsByCategory({ category, count })
+    : await findLatestPosts({ count })
+  : [];
+
+const resolvedLinkUrl = linkUrl ?? (category ? getPermalink(category, 'category') : getBlogPermalink());
 ---
 
 {
-  APP_BLOG.isEnabled ? (
+  APP_BLOG.isEnabled && posts.length > 0 ? (
     <WidgetWrapper id={id} isDark={isDark} containerClass={classes?.container as string} bg={bg}>
       <div class="flex flex-col lg:justify-between lg:flex-row mb-8">
         {title && (
@@ -43,8 +51,8 @@ const posts = APP_BLOG.isEnabled ? await findLatestPosts({ count }) : [];
               class="text-3xl font-bold tracking-tight sm:text-4xl sm:leading-none group font-heading mb-2"
               set:html={title}
             />
-            {APP_BLOG.list.isEnabled && linkText && linkUrl && (
-              <Button variant="link" href={linkUrl}>
+            {APP_BLOG.list.isEnabled && linkText && resolvedLinkUrl && (
+              <Button variant="link" href={resolvedLinkUrl}>
                 {' '}
                 {linkText} »
               </Button>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,10 +15,13 @@ const metadata = {
 
   <HeroText tagline="Welcome to Siva's Blog" title="Inspire, Ideate, and Innovate!" />
 
-  <!-- BlogLatestPosts Widget ************** -->
+  <!-- BlogLatestPosts Widgets, one row per category ************** -->
 
-  <BlogLatestPosts
-    title="Latest Posts"
-    information={`Notes on data platforms, platform engineering, and enterprise strategy — plus the occasional reflection.`}
-  />
+  <BlogLatestPosts title="AI Strategies" category="ai-strategies" count={4} />
+
+  <BlogLatestPosts title="Enterprise Strategies" category="enterprise-strategies" count={4} />
+
+  <BlogLatestPosts title="Data Platforms" category="data-platforms" count={4} />
+
+  <BlogLatestPosts title="Platform Engineering" category="platform-engineering" count={4} />
 </Layout>

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -174,6 +174,19 @@ export const findLatestPosts = async ({ count }: { count?: number }): Promise<Ar
 };
 
 /** */
+export const findPostsByCategory = async ({
+  category,
+  count,
+}: {
+  category: string;
+  count?: number;
+}): Promise<Array<Post>> => {
+  const posts = await fetchPosts();
+  const matched = posts.filter((post) => post.category?.slug === category);
+  return count ? matched.slice(0, count) : matched;
+};
+
+/** */
 export const getStaticPathsBlogList = async ({ paginate }: { paginate: PaginateFunction }) => {
   if (!isBlogEnabled || !isBlogListRouteEnabled) return [];
   return paginate(await fetchPosts(), {


### PR DESCRIPTION
Replaces the single "Latest Posts" list with one row per category (AI Strategies, Enterprise Strategies, Data Platforms, Platform Engineering), each linking to its category archive. Rows with no matching posts are hidden automatically.