### PR TITLE
Disable astro-compress CSS pass that strips Tailwind v4 media queries

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -60,7 +60,11 @@ export default defineConfig({
     ),
 
     compress({
-      CSS: true,
+      // csso (astro-compress's CSS minifier) can't parse Tailwind v4's range
+      // media queries (`@media (width>=48rem)`) and silently drops them,
+      // stripping every responsive/dark variant from the built CSS. Vite
+      // already minifies CSS, so skip the extra pass.
+      CSS: false,
       HTML: {
         'html-minifier-terser': {
           removeAttributeQuotes: false,


### PR DESCRIPTION
csso can't parse Tailwind v4's range media queries (@media (width>=48rem)) and silently drops them, removing every responsive variant from the built CSS — production showed the mobile hamburger and single-column layout at desktop widths. Vite already minifies CSS, so the extra pass only saved ~16 KB while breaking the layout.